### PR TITLE
CCID: Fix misleading read length

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1672,7 +1672,7 @@ time_request:
 	}
 
 	/* we have read less (or more) data than the CCID frame says to contain */
-	if (length-10 != dw2i(cmd, 1))
+	if (length-10 < dw2i(cmd, 1))
 	{
 		DEBUG_CRITICAL3("Can't read all data (%d out of %d expected)",
 			length-10, dw2i(cmd, 1));


### PR DESCRIPTION
Currently, when some extended APDU are processed, we get the following
error:
  CCID_Receive() Can't read all data 49174kbytes

In fact, the processing of the length of the APDU is not correct. For
example:
  00000002 commands.c:1726:CmdXfrBlockAPDU_short() T=0: 9 bytes
  00000003 -> 000000 6F 09 00 00 00 00 2D 00 00 00 00 A4 09 04 04 3F 00 D0 03
  00033873 <- 000000 80 02 00 00 00 00 2D 00 00 00 61 27 00 00 00 00 00 00 00
    [...]
  00002330 commands.c:1682:CCID_Receive() Can't read all data (49174 out of 2 expected)

According to the log, the response should be correct but the reader may
add too many zeros to the response. The actual response APDU is 61 27.
If we check the complete logs/dumps, all the payload till the end is
full of 00 .. 00.

In fact, the check of the length of the data should be less strict.
Let's be tolerant as along as we get enough payload.

Suggested-by: @godfreychung
Fix: issue #19