### PR TITLE
Added a switch to use the dylib when compiling on a mac.

### DIFF
--- a/MacOSX/configure
+++ b/MacOSX/configure
@@ -23,6 +23,21 @@
 # make install
 # the driver is installed in /usr/libexec/SmartCardServices/drivers
 
+usage="$(basename "$0") [-Bh]
+
+    -B  Allows for configuration to use dylib. This is necessary for Homebrew
+    -h  Prints this help text"
+
+while getopts "Bh" opt; do
+  case $opt in
+    B) IS_HOMEBREW=0; shift ;;
+    h) echo "$usage"
+       exit ;;
+    *) IS_HOMEBREW=1 ;;
+  esac
+done
+
+
 # Colors
 RED="\033[31m"
 NORMAL="\033[0m"
@@ -48,8 +63,8 @@ LIBUSB_ARCHIVE="$LIBUSB_DIR"/libusb-1.0.a
 LIBUSB_CFLAGS=$(pkg-config --cflags --static libusb-1.0)
 LIBUSB_LIBS=$(pkg-config --libs --static libusb-1.0)
 
-if ls "$LIBUSB_DIR"/libusb-1.0*.dylib 2> /dev/null
-then
+ls -1 "$LIBUSB_DIR"/libusb-1.0*.dylib > /dev/null 2>&1
+if [ "$?" ] && [ ! $IS_HOMEBREW ]; then
 	echo -en $RED
 	echo "*****************************"
 	echo "Dynamic library libusb found in $LIBUSB_DIR"


### PR DESCRIPTION
The current version of acsccid cannot be packaged using Homebrew. This is because the build will not allow for the use of a dylib for libusb. This patch adds a switch to the mac version of the `./configure` file that allows for this to be configured for compilation using the dylib. In turn, this will allow a Homebrew formula to be built for the package.